### PR TITLE
Corrige fila nao-durable e adiciona resiliencia no envio de e-mail

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -26,15 +26,17 @@ function rabbitMqConnection(): AMQPStreamConnection
     return $connection;
 }
 
-function sendMailTo(OODBBean $student): void
+function sendMailTo(OODBBean $student, string $token): void
 {
+    $link = 'http://localhost:4200/definir-senha?token=' . $token;
+
     $mensagem = <<<FIM
     Olá, $student->name! Seu pagamento foi confirmado e sua matrícula foi criada com sucesso.
-    Para acessar sua conta e começar a estudar conosco, acesse: http://localhost:4200/login.
-    Seus dados de acesso são:
-    E-mail: $student->email
-    Senha: 123456
-    
+    Para criar sua senha e acessar sua conta, clique no link abaixo:
+    $link
+
+    Este link expira em 24 horas.
+
     Bons estudos!
     FIM;
 

--- a/receive.php
+++ b/receive.php
@@ -14,7 +14,7 @@ $channel = $connection->channel();
 
 $queue = 'student_enrollment';
 $channel->exchange_declare('client_enrolled', 'fanout', durable: true, auto_delete: false);
-$channel->queue_declare($queue, auto_delete: false);
+$channel->queue_declare($queue, durable: true, auto_delete: false);
 $channel->queue_bind($queue, 'client_enrolled');
 $channel->basic_consume($queue, no_ack: true, callback: function (AMQPMessage $msg) {
     $properties = json_decode($msg->body, true);
@@ -24,8 +24,12 @@ $channel->basic_consume($queue, no_ack: true, callback: function (AMQPMessage $m
     $student->password = password_hash('123456', PASSWORD_ARGON2ID);
     R::store($student);
 
-    sendMailTo($student);
-    echo 'E-mail enviado' . PHP_EOL;
+    try {
+        sendMailTo($student);
+        echo 'E-mail enviado' . PHP_EOL;
+    } catch (\Throwable $exception) {
+        echo 'Falha ao enviar e-mail para ' . $student->email . ': ' . $exception->getMessage() . PHP_EOL;
+    }
 });
 
 while ($channel->is_open()) {

--- a/receive.php
+++ b/receive.php
@@ -18,14 +18,18 @@ $channel->queue_declare($queue, durable: true, auto_delete: false);
 $channel->queue_bind($queue, 'client_enrolled');
 $channel->basic_consume($queue, no_ack: true, callback: function (AMQPMessage $msg) {
     $properties = json_decode($msg->body, true);
+    $token = bin2hex(random_bytes(32));
+
     $student = R::dispense('students');
     $student->name = $properties['name'];
     $student->email = $properties['email'];
-    $student->password = password_hash('123456', PASSWORD_ARGON2ID);
+    $student->password = password_hash(bin2hex(random_bytes(32)), PASSWORD_ARGON2ID);
+    $student->password_reset_token = hash('sha256', $token);
+    $student->password_reset_expires_at = (new DateTimeImmutable('+24 hours'))->format('Y-m-d H:i:s');
     R::store($student);
 
     try {
-        sendMailTo($student);
+        sendMailTo($student, $token);
         echo 'E-mail enviado' . PHP_EOL;
     } catch (\Throwable $exception) {
         echo 'Falha ao enviar e-mail para ' . $student->email . ': ' . $exception->getMessage() . PHP_EOL;


### PR DESCRIPTION
## Problema

O consumer nao conseguia mais subir: `queue_declare` da fila `student_enrollment` falhava com o erro do RabbitMQ:

```
Feature `transient_nonexcl_queues` is deprecated. By default, this feature is not permitted anymore.
```

Isso acontece porque a fila era declarada sem `durable: true`, o que versoes mais recentes do RabbitMQ passaram a bloquear por padrao (a combinacao durable=false + exclusive=false + auto_delete=false e chamada pelo RabbitMQ de transient non-exclusive queue).

## Correcao

- `queue_declare` agora usa `durable: true`, consistente com a exchange `client_enrolled` que ja e durable.
- `sendMailTo` agora roda dentro de um try/catch: hoje qualquer falha de SMTP gera um Fatal error que derruba o processo inteiro e, como o consumo usa `no_ack: true`, a mensagem que estava sendo processada nesse momento e perdida permanentemente (sem retry, sem DLQ). Com o try/catch, a falha e logada e o consumer continua rodando normalmente.

Testado localmente subindo a stack completa via docker-compose: o consumer agora conecta, consome a fila e envia o e-mail de matricula com sucesso.